### PR TITLE
Enable login test with empty email / pass again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added more `DownloadController` unit tests, including a new `DeleteCache` `admin`-only API. [#729](https://github.com/utetrapp/geli/issues/729)
 - Added `'Misc.'` front-end admin sub-component with cache-clearing control re. the `DeleteCache` API. [#729](https://github.com/utetrapp/geli/issues/729)
 - Added dsgvo delete user data [#775](https://github.com/utetrapp/geli/issues/775)
+- Add Test if error when invalid user/pass [#825](https://github.com/utetrapp/geli/pull/825)
 
 ### Changed
 - Minor Fixes and Adaptations and Mergefailure fixes. [#785] (https://github.com/utetrapp/geli/issues/785)

--- a/app/webFrontend/e2e/login.e2e-spec.ts
+++ b/app/webFrontend/e2e/login.e2e-spec.ts
@@ -15,15 +15,20 @@ describe('Login-form', () => {
     expect(page.getInputPassword().isPresent()).toBeTruthy();
   });
 
-  // Test randomly fails on travis therefore disabled
-  // it('show error when email or password empty', async () => {
-  //   await page.navigateTo();
-  //
-  //   await page.getLoginButton().click();
-  //   await browser.waitForAngular(); // ensure that there are no running http requests
-  //
-  //   expect(page.getSnackBar().getText()).toContain('Login failed: auth.loginFailedError.undefined');
-  // });
+  it('show error when email or password invalid', async () => {
+    await page.navigateTo();
+
+    const email = page.getInputEmail();
+    email.sendKeys('invalidEmail');
+
+    const password = page.getInputPassword();
+    password.sendKeys('wrongPassword');
+
+    await page.getLoginButton().click();
+    await browser.waitForAngular(); // ensure that there are no running http requests
+
+    expect(page.getSnackBar().getText()).toContain('Login failed: Your login details could not be verified. Please try again');
+  });
 
   it('should login with valid credentials', async () => {
     await page.navigateTo();


### PR DESCRIPTION
I guess something is happening when input is focused. Lets see if build
works when entering an empty string into email / pass.